### PR TITLE
Add support for color and other attributes

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -6,7 +6,7 @@ function upgradeElement(element) {
 	}
 }
 
-export default function attributes({id, ripple, primary, primaryDark, active, disabled, large, shadow, config}, noupgrade) {
+export default function attributes({id, ripple, primary, primaryDark, color, textColor, active, disabled, large, shadow, config}, noupgrade) {
 	let attr = {};
 	attr.class = [];
 	attr.class.toString = () => attr.class.join(' ');

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -20,7 +20,13 @@ export default function attributes({id, ripple, primary, primaryDark, active, di
 	if(primary) attr.class.push('mdl-color--primary');
 	if(primaryDark) attr.class.push('mdl-color--primary-dark');
 	if(shadow) attr.class.push(`mdl-shadow--${shadow}dp`);
-	if(arguments[0].class) attr.class.push(arguments[0].class);
+	if(color) attr.class.push(`mdl-color--${color}`);
+
+	let classArg = arguments[0].class;
+	if(classArg) {
+		if(typeof(classArg) === 'string') attr.class.push(classArg);
+		else attr.class.push.apply(attr.class, classArg); // extend with array of classes
+	}
 
 	/* Keep all event handlers */
 	for(let prop in arguments[0]) {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -21,6 +21,7 @@ export default function attributes({id, ripple, primary, primaryDark, active, di
 	if(primaryDark) attr.class.push('mdl-color--primary-dark');
 	if(shadow) attr.class.push(`mdl-shadow--${shadow}dp`);
 	if(color) attr.class.push(`mdl-color--${color}`);
+	if(textColor) attr.class.push(`mdl-color-text--${textColor}`);
 
 	let classArg = arguments[0].class;
 	if(classArg) {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -25,8 +25,12 @@ export default function attributes({id, ripple, primary, primaryDark, color, tex
 
 	let classArg = arguments[0].class;
 	if(classArg) {
-		if(typeof(classArg) === 'string') attr.class.push(classArg);
-		else attr.class.push.apply(attr.class, classArg); // extend with array of classes
+		if(typeof(classArg) === 'string') {
+			attr.class.push(classArg);
+		}
+		else {
+			attr.class.push.apply(attr.class, classArg); // extend with array of classes
+		}
 	}
 
 	/* Keep all event handlers */

--- a/src/button.js
+++ b/src/button.js
@@ -5,10 +5,10 @@ export let Button = {
 	view(ctrl, args, ...children) {
 		args = args || {};
 		let attr = attributes(args);
-		let {raised, accent, color, primary} = args;
+		let {raised, accent, colored, primary} = args;
 
 		attr.class.push('mdl-button', 'mdl-js-button');
-		if(color) attr.class.push('mdl-button--colored');
+		if(colored) attr.class.push('mdl-button--colored');
 		if(accent) attr.class.push('mdl-button--accent');
 		if(raised) attr.class.push('mdl-button--raised');
 		if(primary) attr.class.push('mdl-button--primary');
@@ -21,11 +21,11 @@ export let Fab = {
 	view(ctrl, args, ...children) {
 		args = args || {};
 		let attr = attributes(args);
-		let {raised, mini, accent, color, primary} = args;
+		let {raised, mini, accent, colored, primary} = args;
 
 		attr.class.push('mdl-button', 'mdl-js-button');
 		attr.class.push(mini ? 'mdl-button--mini-fab' : 'mdl-button--fab');
-		if(color) attr.class.push('mdl-button--colored');
+		if(colored) attr.class.push('mdl-button--colored');
 		if(accent) attr.class.push('mdl-button--accent');
 		if(raised) attr.class.push('mdl-shadow--4dp');
 		if(primary) attr.class.push('mdl-button--primary');

--- a/src/layout/header.js
+++ b/src/layout/header.js
@@ -12,6 +12,7 @@ export let Header = {
 		if(scroll) attr.class.push('mdl-layout__header--scroll');
 		if(waterfall) attr.class.push('mdl-layout__header--waterfall');
 		if(transparent) attr.class.push('mdl-layout__header--transparent');
+		if(castShadow) attr.class.push('is-casting-shadow');
 
 		return <header {...attr}>{children}</header>;
 	}

--- a/src/layout/header.js
+++ b/src/layout/header.js
@@ -5,7 +5,7 @@ export let Header = {
 	view(ctrl, args, ...children) {
 		args = args || {};
 		let attr = attributes(args);
-		let {scroll, waterfall, transparent} = args;
+		let {scroll, waterfall, transparent, castShadow} = args;
 
 		attr.class.push('mdl-layout__header');
 


### PR DESCRIPTION
## Added attributes
- color (custom colors from the MDL palette besides prmary and primary dark)
- is-casting-shadow for LayoutHeader
- more than one custom CSS class (class attribute can be an array)
## Remarks

This pull request changes the 'color' arugment on Button to 'colored' (just like the real MDL attribute name) to avoid conflict with the newly added color attribute.
