### PR TITLE
Fix spacer MDL class

### DIFF
--- a/src/misc.js
+++ b/src/misc.js
@@ -13,7 +13,7 @@ export let Icon = {
 export let Spacer = {
 	view(ctrl, args) {
 		let attr = attributes(args || {});
-		attr.class.push('mdl-layout__spacer');
+		attr.class.push('mdl-layout-spacer');
 
 		return <div {...attr} />;
 	}


### PR DESCRIPTION
The CSS class name is wrong. I can't really wrap my mind around the MDL naming convention, but it should be `mdl-layout-spacer` apparently.
