### PR TITLE
Support icon buttons

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -1,17 +1,22 @@
 import m from 'mithril';
 import attributes from './attributes';
+import {Icon} from './misc';
 
 export let Button = {
 	view(ctrl, args, ...children) {
 		args = args || {};
 		let attr = attributes(args);
-		let {raised, accent, colored, primary} = args;
+		let {raised, accent, colored, primary, icon} = args;
 
 		attr.class.push('mdl-button', 'mdl-js-button');
 		if(colored) attr.class.push('mdl-button--colored');
 		if(accent) attr.class.push('mdl-button--accent');
 		if(raised) attr.class.push('mdl-button--raised');
 		if(primary) attr.class.push('mdl-button--primary');
+		if(icon) {
+			attr.class.push('mdl-button--icon');
+			if(typeof(icon) === 'string' && children.length === 0) children = <Icon>{icon}</Icon>;
+		}
 
 		return <button {...attr}>{children}</button>;
 	}


### PR DESCRIPTION
Icon buttons need a special CSS class (`mdl-button--icon`) on the button element and a nested icon element. Keeping that in mind, I've added an `icon` option argument to mdl.Button, which can be used in two ways:
1. Setting `icon` to any truthy value will just add the `mdl-button--icon` CSS class. The user will have to specify the icon manually.
2. Setting `icon` to a string value without explicitly specifying children elements inside the button will automatically add a child Icon element with the provided string as the icon name. This shortcut should be good enough for 99% of the use cases.
