### PR TITLE
Add full-featured cards

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -1,3 +1,5 @@
+import { applyMixins } from './mixin';
+
 /* globals componentHandler */
 
 function upgradeElement(element) {
@@ -6,10 +8,10 @@ function upgradeElement(element) {
 	}
 }
 
-export default function attributes({id, ripple, primary, primaryDark, color, textColor, active, disabled, large, shadow, config}, noupgrade) {
+export default function attributes({id, ripple, primary, primaryDark, color, textColor, active, disabled, large, shadow, mixin, config}, ctx) {
 	let attr = {};
 	attr.class = [];
-	attr.class.toString = () => attr.class.join(' ');
+	attr.class.toString = function() { return this.join(' '); };
 
 	/* Some common attributes to transfer and set */
 	if(id) attr.id = id;
@@ -38,11 +40,14 @@ export default function attributes({id, ripple, primary, primaryDark, color, tex
 		if(prop.substring(0, 2) === 'on') attr[prop] = arguments[0][prop];
 	}
 
+	/* Apply mixins */
+	if(mixin) applyMixins(mixin, attr, ctx);
+
 	/* Try to upgrade all elements and also run a config attribute if passed */
 	attr.config = function(e, isInitialized) {
 		if(config) config(...arguments);
 
-		if(!isInitialized && !noupgrade) upgradeElement(e);
+		if(!isInitialized && !(ctx && ctx.noupgrade)) upgradeElement(e);
 	};
 
 	return attr;

--- a/src/card.js
+++ b/src/card.js
@@ -1,5 +1,6 @@
 import m from 'mithril';
 import attributes from './attributes';
+import {Mixable} from './mixin';
 
 export let Card = {
 	view(ctrl, args, ...children) {
@@ -12,31 +13,89 @@ export let Card = {
 	}
 };
 
+// Create a component from a simple function that returns a mithril view
+// independent of the controller.
+function simpleComponent(fn) {
+	return {
+		view(ctrl, ...args) {
+			return fn(...args);
+		}
+	};
+}
+
+function cardTitleText({size}, text) {
+	size = size || 2;
+	return m('h' + size.toString(), {'class': 'mdl-card__title-text'}, text);
+}
+
+function cardSubtitleText({size}, text) {
+	size = size || 3;
+	return m('h' + size.toString(), {'class': 'mdl-card__subtitle-text'}, text);
+}
+
+export let CardTitleText = simpleComponent(cardTitleText);
+export let CardSubtitleText = simpleComponent(cardSubtitleText);
+
+// Usage:
+//	 MSX:
+//	 * Both titles specified as attributes:
+//		 <CardTitle title='Title Text' subtitle='Subtitle Text' />
+//	 * Subtitle attribute, title string child:
+//		 <CardTitle subtitle='Subtitle text'>Title Text</CardTitle>
+//	 * Subtitle attribute, explicit title element child:
+//		 <CardTitle subtitle='Subtitle text'><CardTitleText>Title Text</CardTitleText></CardTitle>
+//	 * Both title and subtitle are explicit child elements:
+//		 <CardTitle>
+//			 <CardTitleText>Title Text</CardTitleText>
+//			 <CardSubtitleText>Subtitle Text</SubtitleText>
+//		 </CardTitle>
+//	 With m() function interface:
+//	 * Shorthand with two string children:
+//		 m(CardTitle, 'Title Text', 'Subtitle Text')
 export let CardTitle = {
 	view(ctrl, args, ...children) {
 		args = args || {};
 		let attr = attributes(args);
-		let {expand, size} = args;
+		let {expand} = args;
 
 		attr.class.push('mdl-card__title');
 		if(expand) attr.class.push('mdl-card--expand');
 
-		size = size || 2;
+		// If title is specified directly as an attribute don't use children
+		if(args.title) {
+			children = [args.title];
+		}
 
-		return <div {...attr}><h2 class="mdl-card__title-text">{children}</h2></div>;
-	}
-};
+		// Title is given as a string, assume <h2> by default
+		let title = children[0];
+		if(typeof title === 'string') {
+			children[0] = cardTitleText({size: args.size}, title);
+		}
 
-export let CardSupportingText = {
-	view(ctrl, args, ...children) {
-		args = args || {};
-		let attr = attributes(args);
-		let {border, expand} = attr;
-
-		attr.class.push('mdl-card__title-text');
-		if(border) attr.class.push('mdl-card--border');
-		if(expand) attr.class.push('mdl-card--expand');
+		// Subtitle string is specified, assume <h3> by default
+		let subtitle = args.subtitle || children[1];
+		if(typeof subtitle === 'string') {
+			children[1] = cardSubtitleText({subtitleSize: args.subtitleSize}, title);
+		}
 
 		return <div {...attr}>{children}</div>;
 	}
 };
+
+export class CardSection extends Mixable {
+	constructor(type) {
+		super('div');
+		this.type = type;
+	}
+
+	applyMixin({border, expand}, attr) {
+		attr.class.push(`mdl-card__${this.type}`);
+		if(border) attr.class.push('mdl-card--border');
+		if(expand) attr.class.push('mdl-card--expand');
+	}
+}
+
+export let CardActions = new CardSection('actions');
+export let CardMedia = new CardSection('media');
+export let CardSupportingText = new CardSection('supporting-text');
+

--- a/src/layout/tabs.js
+++ b/src/layout/tabs.js
@@ -14,7 +14,7 @@ export let Tabs = {
 export let Tab = {
 	view(ctrl, args, title) {
 		args = args || {};
-		let attr = attributes(args, args.config);
+		let attr = attributes(args, {noupgrade: args.config});
 		attr.class.push('mdl-layout__tab');
 		attr.href = args.href;
 

--- a/src/mdl.js
+++ b/src/mdl.js
@@ -7,4 +7,4 @@ export {Button, Fab} from './button';
 export {Grid, Cell} from './grid';
 export {ProgressBar} from './loading';
 export {TextInput} from './input';
-export {Card, CardTitle, CardSupportingText} from './card';
+export {Card, CardTitle, CardTitleText, CardSubtitleText, CardSupportingText, CardActions, CardMedia} from './card';

--- a/src/mdl.js
+++ b/src/mdl.js
@@ -1,5 +1,6 @@
 export {default as attributes} from './attributes';
 
+export {Mixable} from './mixin';
 export {Icon, Spacer} from './misc';
 export {Layout, Header, HeaderRow, Title, Tabs, Tab, Drawer, Navigation, NavLink, Content} from './layout';
 export {Button, Fab} from './button';

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,0 +1,89 @@
+import attributes from './attributes';
+
+let isArray = Array.isArray || ((obj)=> Object.prototype.toString.call(obj) === '[object Array]');
+
+export class Component {
+	constructor(tag) {
+		this.tag = tag;
+	}
+
+	// This is the default view for mixable objects which just mixes them in into a div.
+	view(ctrl, args, ...children) {
+		args = args || {};
+		let ctx = {ctrl, children};
+		let attr = attributes(args, ctx);
+
+		if(this.customizeView != null) {
+			this.customizeView(args, attr, ctx);
+		}
+
+		// MSX doesn't evalute tag names so we build the virtual DOM by ourselves here:
+		// We could use m() instead. I'm not sure about the performance impact.
+		return {
+			tag: this.tag,
+			attrs: attr,
+			children: ctx.children
+		};
+	}
+}
+
+// This is the default view for mixable components which just mixes them in into an HTML element (<div> by default).
+export class Mixable extends Component {
+	// tag name is optional ('div' by default)
+	// arg is either the applyMixin function or an object with properties to override
+	constructor(tag, arg) {
+		if(typeof tag !== 'string') {
+			// No tag is specified: default is DIV.
+			arg = tag;
+			tag = 'div';
+		}
+		super(tag);
+
+		if(typeof arg === 'function') {
+			this.applyMixin = arg;
+		}
+		else if(arg) {
+			for (let prop in arg) {
+				if (arg.hasOwnProperty(prop)) this[prop] = arg[prop];
+			}
+		}
+	}
+
+	// applyMixin signature is `applyMixin(args, attr, ctx)`.
+	applyMixin() {
+		throw new Error(`applyMixin() is not implemented on ${this}`);
+	}
+
+	mixin(args) {
+		return (attr, ctx)=> { this.applyMixin(args, attr, ctx); };
+	}
+
+	customizeView(args, attr, ctx) {
+		this.applyMixin(args, attr, ctx);
+	}
+}
+
+export function applyMixin(mixin, attr, ctx) {
+	if(typeof mixin === 'function') {
+		// Apply a mixin function
+		mixin(attr, ctx);
+	}
+	else {
+		// Apply attributes from mixin
+		for (let prop in mixin) {
+			if(mixin.hasOwnProperty(prop)) attr[prop] = mixin[prop];
+		}
+	}
+}
+
+export function applyMixins(mixins, attr, ctx) {
+	if(isArray(mixins)) {
+		for (let mixin of mixins) {
+			applyMixin(mixin, attr, ctx);
+		}
+	}
+	else {
+		applyMixin(mixins, attr, ctx);
+	}
+}
+


### PR DESCRIPTION
Added a more complete implementation of cards based on mixins.
## Usage
### MSX
- Both titles specified as attributes:

``` html
   <CardTitle title='Title Text' subtitle='Subtitle Text' />
```
- Subtitle attribute, title string child:

``` html
   <CardTitle subtitle='Subtitle text'>Title Text</CardTitle>
```
- Subtitle attribute, explicit title element child:

``` html
   <CardTitle subtitle='Subtitle text'><CardTitleText>Title Text</CardTitleText></CardTitle>
```
- Both title and subtitle are explicit child elements:

``` html
   <CardTitle>
     <CardTitleText>Title Text</CardTitleText>
     <CardSubtitleText>Subtitle Text</SubtitleText>
   </CardTitle>
```
### m() syntax
- Shorthand with two string children:

``` js
   m(CardTitle, 'Title Text', 'Subtitle Text')
```
