### PR TITLE
Disable `upgradeElement` call on tabs element

### DIFF
--- a/src/layout/tabs.js
+++ b/src/layout/tabs.js
@@ -4,7 +4,7 @@ import attributes from '../attributes';
 export let Tabs = {
 	view(ctrl, args, ...children) {
 		args = args || {};
-		let attr = attributes(args);
+		let attr = attributes(args, true);
 		attr.class.push('mdl-layout__tab-bar');
 
 		return <div {...attr}>{children}</div>;


### PR DESCRIPTION
Calling `upgradeElement` to refresh `ripple` effect doesn't work on `mdl-layout__tab-bar`
