### PR TITLE
Remove branch name from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/PaulAvery/mithril-mdl.git"
   },
   "dependencies": {
-    "mithril": "lhorie/mithril.js#next"
+    "mithril": "^0.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",


### PR DESCRIPTION
Mithril 0.2.1 is already released. I think using npm package is better than git (for performance or anything).
