### PR TITLE
Fix for minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/PaulAvery/mithril-mdl.git"
   },
   "dependencies": {
-    "mithril": "^0.2.2-rc.1"
+    "mithril": "~0.2.2-rc.1"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",


### PR DESCRIPTION
mithril-mdl is not compatible with an isomorphic usage. Cause mithril v1.* use the window global.
Fixing the version permit to not use mithril v1.* but v0.*